### PR TITLE
Passing importName and importNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ yarn add -D babel-plugin-dynamic-import-override
 
 - *`successHandler`* - javascript code to be called inside then clause, result  is accesible in `res`.
 
+*NOTE:* successHandler and errorHandler should be wrapped as string.
+Dynamic Import that has failed/succeeded can be accessed via following variables:
+  - `importNode` - Contains full code of dynamic import.
+      Example: `import('./Home.js')`
+  - `importName` - Contains file name of dynamic import.
+      Example: `./Home.js`
+
 ### Skip Overriding Dynamic Import
 
 To skip overriding some dynamic imports, use following magic comment in the dynamic imports

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function({template}) {
       CallExpression(path, state) {
         if(path.node.callee.type == 'Import' && path.node.callee.loc) {
           let importNode = generator(path.node).code;
+          let importName = generator(path.node.arguments[0]).code;
           // Skip overriding dynamic import if skipImportOverride is mentioned in magic comment
           let skipOverrideStart = importNode.indexOf('skipImportOverride');
           if (skipOverrideStart > -1) {
@@ -42,7 +43,8 @@ module.exports = function({template}) {
             plugins: ["dynamicImport"],
             preserveComments: true
           })({
-            importNode: importNode
+            importNode: importNode,
+            importName: importName
           });
           path.replaceWith(newProgramNode);
         }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ module.exports = function({template}) {
           let newProgramNode = template(newImport, {
             plugins: ["dynamicImport"],
             preserveComments: true
-          })();
+          })({
+            importNode: importNode
+          });
           path.replaceWith(newProgramNode);
         }
       }


### PR DESCRIPTION
Passing importName and importNode to plugin

## Description

Passing importName and importNode to plugin which will enable to use them inside success and error handlers

## Motivation and Context

successHandler and errorHandler might want to do something with the dynamic import that failed/succeeded. Import Name and Import Node will be available inside variable **importNode** and **importName** and can be used in handlers as **%%importNode%%** and **%%importName%%**.
This syntax, because both handlers should be returned as string.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
